### PR TITLE
Update cluster.ts documentattion

### DIFF
--- a/packages/library-legacy/src/utils/cluster.ts
+++ b/packages/library-legacy/src/utils/cluster.ts
@@ -15,6 +15,7 @@ export type Cluster = 'devnet' | 'testnet' | 'mainnet-beta';
 
 /**
  * Retrieves the RPC API URL for the specified cluster
+ * @param {cluster} - The cluster name of the RPC API URL to use. Possible options: 'devnet' | 'testnet' | 'mainnet-beta'
  */
 export function clusterApiUrl(cluster?: Cluster, tls?: boolean): string {
   const key = tls === false ? 'http' : 'https';


### PR DESCRIPTION
This commit adds a small tweak to the documentation that explicitly states the possible choices that clusterApiUrl can take on.